### PR TITLE
Register callback for darkmode changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "cordova": {
     "id": "cordova-plugin-darkmode",
     "platforms": [
-      "android"
+      "android",
+      "ios"
     ]
   },
   "repository": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,5 +24,15 @@
 	 <source-file src="src/android/DarkMode.java" target-dir="src/com/openmove/darkmode/"/>
   </platform>
 
+  <platform name="ios">
+      <config-file target="config.xml" parent="/*">
+          <feature name="DarkMode">
+              <param name="ios-package" value="DarkMode" onload="true" />
+              <param name="onload" value="true" />
+          </feature>
+      </config-file>
+    <header-file src="src/ios/DarkMode.h" />
+    <source-file src="src/ios/DarkMode.m" />
+  </platform>
 
 </plugin>

--- a/src/android/DarkMode.java
+++ b/src/android/DarkMode.java
@@ -2,65 +2,121 @@ package com.openmove.darkmode;
 
 import org.apache.cordova.*;
 import org.json.JSONArray;
+import org.json.JSONException;
 
 import android.util.Log;
 import android.content.res.Configuration;
 import android.provider.Settings;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class DarkMode extends CordovaPlugin {
-    String TAG = "DarkModePlugin";
+    private static final String TAG = "DarkModePlugin";
+    private static final String SEM_HIGH_CONTRAST = "high_contrast";
+    private static final String DARKMODE_SETTING = "darkmode";
+    private static final String INVERSION_SETTING = "inversion";
+    private static final String REGISTER_SETTING = "register";
+    private static final String UNREGISTER_SETTING = "unregister";
+    private final Map<String, CallbackContext> callbackContexts = new HashMap<>();
+    private Boolean lastDarkMode = null;
 
     @Override
-    public boolean execute(String action, JSONArray data, CallbackContext callbackContext){
-        if (action.equals("darkmode")) {
-
-            int a = cordova.getActivity().getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-
-        switch(a) {
-            case Configuration.UI_MODE_NIGHT_NO:
-                Log.d(TAG, "Dark Mode: off");
-		callbackContext.success("false");
-                break;
-            // Night mode is not active, we're in day time
-            case Configuration.UI_MODE_NIGHT_YES:
-                Log.d(TAG, "Dark Mode: on");
-		callbackContext.success("true");
-                break;
-            // Night mode is active, we're at night!
-            case Configuration.UI_MODE_NIGHT_UNDEFINED:
-                // We don't know what mode we're in, assume notnight
-                Log.d(TAG, "Dark Mode: undefined");
-		callbackContext.success("false");
-                break;
-        	}
+    public boolean execute(String action, JSONArray data, CallbackContext callbackContext) {
+        Log.e(TAG, action);
+        if (action.equals(DARKMODE_SETTING)) {
+            callbackContext.success(isDarkModeEnabled() ? "true" : "false");
             return true;
+        } else if (action.equals(INVERSION_SETTING)) {
+            callbackContext.success(isInversionEnabled() ? "true" : "false");
+            return true;
+        } else if (action.equals(REGISTER_SETTING)) {
+            String setting;
+            try {
+                setting = data.getString(0);
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to parse name of setting to register callback", e);
+                callbackContext.error("Failed to parse name of setting to register callback");
+                return true;
+            }
+            if (callbackContexts.containsKey(setting)) {
+                Log.e(TAG, "There is already a callback registered for " + setting);
+                callbackContext.error("There is already a callback registered for " + setting);
+                return true;
+            }
+            final String initialValue;
+            switch (setting) {
+                case DARKMODE_SETTING:
+                    initialValue = isDarkModeEnabled() ? "true" : "false";
+                    break;
+                case INVERSION_SETTING:
+                    // TODO: How can the plugin get notified with system configuration changes?
+                    Log.e(TAG, "Callbacks for setting " + setting + " are not currently supported");
+                    callbackContext.error("Callbacks for setting " + setting + " are not currently supported");
+                    return false;
+                default: {
+                    Log.e(TAG, "Cannot register callback for invalid setting " + setting);
+                    callbackContext.error("Cannot register callback for invalid setting " + setting);
+                    return true;
+                }
+            }
+            callbackContexts.put(setting, callbackContext);
+            // Return with success and keep the callback alive
+            final PluginResult result = new PluginResult(PluginResult.Status.OK, initialValue);
+            result.setKeepCallback(true);
+            callbackContext.sendPluginResult(result);
+            return true;
+        } else if (action.equals(UNREGISTER_SETTING)) {
+            String setting;
+            try {
+                setting = data.getString(0);
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to parse name of setting to register callback", e);
+                callbackContext.error("Failed to parse name of setting to register callback");
+                return true;
+            }
+            final CallbackContext context = callbackContexts.remove(setting);
+            if (context != null) {
+                final PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+                result.setKeepCallback(false);
+                context.sendPluginResult(result);
+            }
+            callbackContext.success();
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-        } else if (action.equals("inversion")) {
+    @Override
+    public void onConfigurationChanged(final Configuration newConfig) {
+        final Boolean darkMode = (newConfig.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        if (!darkMode.equals(lastDarkMode)) {
+            lastDarkMode = darkMode;
+            final CallbackContext context = callbackContexts.get(DARKMODE_SETTING);
+            if (context != null) {
+                final PluginResult result = new PluginResult(PluginResult.Status.OK, darkMode ? "true" : "false");
+                result.setKeepCallback(true);
+                context.sendPluginResult(result);
+            }
+        }
+    }
 
-            boolean isInversionEnabled =  false;
-            int accessibilityEnabled = 0;
+    private boolean isDarkModeEnabled() {
+        return (cordova.getActivity().getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    private boolean isInversionEnabled() {
+        int accessibilityEnabled = 0;
         try {
             accessibilityEnabled = Settings.Secure.getInt(cordova.getActivity().getContentResolver(),
                     android.provider.Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED);
         } catch (Settings.SettingNotFoundException e) {
             Log.d(TAG, "Error finding setting ACCESSIBILITY_DISPLAY_INVERSION_ENABLED: " + e.getMessage());
             Log.d(TAG, "Checking negative color enabled status");
-            final String SEM_HIGH_CONTRAST = "high_contrast";
             accessibilityEnabled = Settings.System.getInt(cordova.getActivity().getContentResolver(), SEM_HIGH_CONTRAST, 0);
         }
-        if (accessibilityEnabled == 1) {
-            Log.d(TAG, "inversion  or negative colour is enabled");
-            isInversionEnabled = true;
-        } else {
-            Log.d(TAG, "inversion  or negative colour is disabled");
-        }
-            callbackContext.success(""+isInversionEnabled);
-
-            return true;
-
-        } else {
-            return false;
-        }
+        return accessibilityEnabled == 1;
     }
 }
 

--- a/src/ios/DarkMode.h
+++ b/src/ios/DarkMode.h
@@ -1,0 +1,7 @@
+#import <Cordova/CDVPlugin.h>
+
+@interface DarkMode : CDVPlugin
+
+- (void)darkmode:(CDVInvokedUrlCommand *)command;
+
+@end

--- a/src/ios/DarkMode.m
+++ b/src/ios/DarkMode.m
@@ -1,0 +1,28 @@
+#import "DarkMode.h"
+
+/**
+ * This plugin initializes Instabug.
+ */
+@implementation DarkMode
+
+/**
+ * Intializes Instabug and sets provided options.
+ *
+ * @param {CDVInvokedUrlCommand*} command
+ *        The command sent from JavaScript
+ */
+- (void) darkmode:(CDVInvokedUrlCommand*)command
+{
+    BOOL enabled = FALSE;
+    if (@available(iOS 12, *))
+    {
+        if (self.viewController.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark)
+        {
+            enabled = TRUE;
+        }
+    }
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:enabled];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+@end

--- a/www/darkmode.js
+++ b/www/darkmode.js
@@ -4,5 +4,11 @@ module.exports = {
     },
     isInversionEnabled: function (successCallback, errorCallback) {
         cordova.exec(successCallback, errorCallback, "DarkMode", "inversion", []);
-    }	
+    },
+    registerCallback: function(setting, successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "DarkMode", "register", [setting]);
+    },
+    unregisterCallback: function(setting, successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "DarkMode", "unregister", [setting]);
+    }
 };


### PR DESCRIPTION
I needed to react in realtime to darkmode changes in Android to keep the app consistent with the setting. For example, when darkmode is enabled via quick controls or by configured schedule. I was able to add functions to this plugin to register/unregister a callback that gets invoked with the new setting value whenever it changes

Here's a pull request in case you are interested in incorporating this into the main plugin.